### PR TITLE
FEATURE: Add support for setting custom attributes on `pre` and `code` elements in the visual editor

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,4 +1,5 @@
 module.exports = {
   printWidth: 100,
-  singleQuote: true
+  singleQuote: true,
+  endOfLine: 'auto',
 };

--- a/plugins/code-syntax-highlight/src/__test__/integration/__snapshots__/codeHighlightPlugin.spec.ts.snap
+++ b/plugins/code-syntax-highlight/src/__test__/integration/__snapshots__/codeHighlightPlugin.spec.ts.snap
@@ -81,3 +81,46 @@ exports[`codeSyntaxHighlightPlugin should render highlighted codeblock element i
   </pre>
 </div>
 `;
+
+exports[`codeSyntaxHighlightPlugin should render custom attributes in wysiwyg 1`] = `
+<div data-language="yaml"
+     class="toastui-editor-ww-code-block-highlighting"
+>
+  <pre spellcheck="false"
+       class="language-yaml"
+  >
+    <code data-language="yaml"
+          spellcheck="false"
+          class="language-yaml"
+    >
+      <span class="token key atrule">
+        martin
+      </span>
+      <span class="token punctuation">
+        :
+      </span>
+      <span class="token key atrule">
+        name
+      </span>
+      <span class="token punctuation">
+        :
+      </span>
+      Martin D'vloper
+      <span class="token key atrule">
+        job
+      </span>
+      <span class="token punctuation">
+        :
+      </span>
+      Developer
+      <span class="token key atrule">
+        skill
+      </span>
+      <span class="token punctuation">
+        :
+      </span>
+      Elite
+    </code>
+  </pre>
+</div>
+`;

--- a/plugins/code-syntax-highlight/src/__test__/integration/codeHighlightPlugin.spec.ts
+++ b/plugins/code-syntax-highlight/src/__test__/integration/codeHighlightPlugin.spec.ts
@@ -78,4 +78,41 @@ describe('codeSyntaxHighlightPlugin', () => {
 
     expect(previewHTML).toMatchSnapshot();
   });
+
+  it('should render custom attributes in wysiwyg', () => {
+    editor.destroy();
+    document.body.removeChild(container);
+
+    container = document.createElement('div');
+    editor = new Editor({
+      el: container,
+      previewStyle: 'vertical',
+      initialValue,
+      plugins: [
+        [
+          codeSyntaxHighlightPlugin,
+          {
+            highlighter: Prism,
+            customAttributes: {
+              pre: { spellcheck: 'false' },
+              code: { spellcheck: 'false' },
+            },
+          },
+        ],
+      ],
+    });
+
+    const elements = editor.getEditorElements();
+
+    mdPreview = elements.mdPreview!;
+    wwEditor = elements.wwEditor!;
+
+    document.body.appendChild(container);
+
+    editor.changeMode('wysiwyg');
+
+    const wwEditorHTML = getWwEditorHTML();
+
+    expect(wwEditorHTML).toMatchSnapshot();
+  });
 });

--- a/plugins/code-syntax-highlight/src/nodeViews/codeSyntaxHighlightView.ts
+++ b/plugins/code-syntax-highlight/src/nodeViews/codeSyntaxHighlightView.ts
@@ -7,6 +7,7 @@ import addClass from 'tui-code-snippet/domUtil/addClass';
 import { cls } from '@/utils/dom';
 import { LanguageSelectBox } from '@/nodeViews/languageSelectBox';
 import type { Emitter } from '@toast-ui/editor';
+import { CustomAttributes } from '@t/index';
 
 type GetPos = (() => number) | boolean;
 
@@ -35,7 +36,8 @@ class CodeSyntaxHighlightView implements NodeView {
     private view: EditorView,
     private getPos: GetPos,
     private eventEmitter: Emitter,
-    private languages: string[]
+    private languages: string[],
+    private customAttributes?: CustomAttributes
   ) {
     this.node = node;
     this.view = view;
@@ -43,6 +45,7 @@ class CodeSyntaxHighlightView implements NodeView {
     this.eventEmitter = eventEmitter;
     this.languageEditing = false;
     this.languages = languages;
+    this.customAttributes = customAttributes;
 
     this.createElement();
     this.bindDOMEvent();
@@ -70,6 +73,14 @@ class CodeSyntaxHighlightView implements NodeView {
     this.contentDOM = code;
   }
 
+  private setAttributes(element: HTMLElement, attributes: Record<string, string>) {
+    Object.keys(attributes).forEach((attribute: string) => {
+      if (attributes?.[attribute]) {
+        element.setAttribute(attribute, attributes?.[attribute]);
+      }
+    });
+  }
+
   private createCodeBlockElement() {
     const pre = document.createElement('pre');
     const code = document.createElement('code');
@@ -85,6 +96,14 @@ class CodeSyntaxHighlightView implements NodeView {
         pre.setAttribute(attrName, attrs[attrName]);
       }
     });
+
+    if (this.customAttributes?.pre) {
+      this.setAttributes(pre, this.customAttributes.pre);
+    }
+
+    if (this.customAttributes?.code) {
+      this.setAttributes(code, this.customAttributes.code);
+    }
 
     pre.appendChild(code);
 
@@ -189,7 +208,10 @@ class CodeSyntaxHighlightView implements NodeView {
   }
 }
 
-export function createCodeSyntaxHighlightView(languages: string[]) {
+export function createCodeSyntaxHighlightView(
+  languages: string[],
+  customAttributes?: CustomAttributes
+) {
   return (node: ProsemirrorNode, view: EditorView, getPos: GetPos, emitter: Emitter) =>
-    new CodeSyntaxHighlightView(node, view, getPos, emitter, languages);
+    new CodeSyntaxHighlightView(node, view, getPos, emitter, languages, customAttributes);
 }

--- a/plugins/code-syntax-highlight/src/plugin.ts
+++ b/plugins/code-syntax-highlight/src/plugin.ts
@@ -13,7 +13,7 @@ export function codeSyntaxHighlightPlugin(
 ): PluginInfo {
   if (options) {
     const { eventEmitter } = context;
-    const { highlighter: prism } = options;
+    const { highlighter: prism, customAttributes } = options;
 
     eventEmitter.addEventType('showCodeBlockLanguages');
     eventEmitter.addEventType('selectLanguage');
@@ -28,7 +28,7 @@ export function codeSyntaxHighlightPlugin(
       toHTMLRenderers: getHTMLRenderers(prism!),
       wysiwygPlugins: [() => codeSyntaxHighlighting(context, prism!)],
       wysiwygNodeViews: {
-        codeBlock: createCodeSyntaxHighlightView(registerdlanguages),
+        codeBlock: createCodeSyntaxHighlightView(registerdlanguages, customAttributes),
       },
     };
   }

--- a/plugins/code-syntax-highlight/types/index.d.ts
+++ b/plugins/code-syntax-highlight/types/index.d.ts
@@ -5,6 +5,11 @@ type PrismJs = typeof Prism & {
   manual: boolean;
 };
 
+type CustomAttributes = {
+  pre?: Record<string, string>;
+  code?: Record<string, string>;
+};
+
 declare global {
   interface Window {
     Prism: PrismJs;
@@ -13,6 +18,7 @@ declare global {
 
 export type PluginOptions = {
   highlighter?: PrismJs;
+  customAttributes?: CustomAttributes;
 };
 
 export default function codeSyntaxHighlightPlugin(


### PR DESCRIPTION
FEATURE: Add support for setting custom attributes on `pre` and `code` elements in the visual editor

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description
This PR builds in support for setting custom attributes for `pre` and `code` elements for rendering in the visual editor. As an example, you could set the `spellcheck` attribute to default to `false` to ensure code isn't spellchecked by the browser "code" elements (where more often than not, is flagged for spelling).

### Business Case
In the example provided above, when users have `spellcheck` enabled for the editor, `code` blocks/elements are spellchecked by the browser. Attempting to modify it outside of the editor by overriding any `pre` and `code` elements with the `spellcheck` attribute to false results in the attribute being removed due to TUI's DOM observer. That's where the need to add in support for setting custom attributes came in. With that, this feature allows forcing TUI to add the spellcheck attribute to the respective elements while in the visual editor without having the DOM observer remove them.

### Documentation

When defining the plugin for `code syntax highlighting` users have the option to also specify custom attributes for `pre` and `code` elements.

To do so, when defining the plugin, use the following syntax
```js
plugins: [
  [
    codeSyntaxHighlightPlugin,
    {
      highlighter: Prism,
      customAttributes: {
        pre: { spellcheck: 'false' },
        code: { spellcheck: 'false' },
      },
    },
  ],
],
```