### PR TITLE
fix(markdown): enhance HTML comment regex pattern for better detection

### DIFF
--- a/apps/editor/src/utils/constants.ts
+++ b/apps/editor/src/utils/constants.ts
@@ -17,6 +17,6 @@ export const HTML_TAG = `(?:${OPEN_TAG}|${CLOSE_TAG})`;
 
 export const reHTMLTag = new RegExp(`^${HTML_TAG}`, 'i');
 export const reBR = /<br\s*\/*>/i;
-export const reHTMLComment = /<! ---->|<!--(?:-?[^>-])(?:-?[^-])*-->/;
+export const reHTMLComment = /<! ---->|<!--(?:-?[^>-])(?:-?[^-])*-->|<!--(?:[^-]|-(?!->))*-->/;
 
 export const ALTERNATIVE_TAG_FOR_BR = '</p><p>';


### PR DESCRIPTION
- Added slight modification to the HTML comment regex pattern
- Improved pattern recognition for finding occurrences in Markdown

---

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description
When HTML comments contain thematic breaks (horizontal lines), [the check for if it's an HTML block is a comment or not](https://github.com/LearnOnDemandSystems/tui.editor/blob/68f42c9e36c0c7a7801bd5392c2512925d92a424/apps/editor/src/convertors/toWysiwyg/toWwConvertors.ts#L338) fails to be recognized properly. The following change adds additional parsing logic on top of the current logic to support thematic breaks in HTML comments.


### Business Case
Users that opt to comment out sections of a document that may contain thematic breaks.

### Issue
With a comment containing a thematic break, it causes an exception in the editor to the thrown and unaware how to handle the thematic break.