### PR TITLE
fix(widget): prevent parsing breakage for widget content with multiple $$

### DIFF
--- a/apps/editor/src/widget/rules.ts
+++ b/apps/editor/src/widget/rules.ts
@@ -22,8 +22,29 @@ export function unwrapWidgetSyntax(text: string) {
   return text;
 }
 
-export function createWidgetContent(info: string, text: string) {
-  return `$$${info} ${text}$$`;
+/**
+ * Creates a widget string safe for insertion into TUI Editor.
+ *
+ * TUI Editor wraps widgets with `$$`, and its parser (ToastMark) treats
+ * `$$` as a special delimiter. If the widget content itself contains `$$`,
+ * ToastMark may incorrectly interpret it as the end of the widget block,
+ * breaking rendering or WYSIWYG behavior.
+ *
+ * This function inserts a zero-width space (`\u200B`) between any `$` characters
+ * that form a `$$` sequence inside the widget content. This prevents the
+ * parser from prematurely closing the widget while remaining invisible to
+ * users in the editor. The resulting string is safe to insert into the editor
+ * and will render correctly in WYSIWYG mode.
+ *
+ * @param info - Metadata or identifier for the widget (e.g., type or ID)
+ * @param content - The raw text content of the widget, which may include `$$`
+ * @returns A string representing the widget, wrapped in `$$` with internal
+ *          `$` sequences made parser-safe
+ */
+export function createWidgetContent(info: string, content: string) {
+  const safeContent = content.replaceAll('$$', `$${'\u200B'}$`);
+
+  return `$$${info} ${safeContent}$$`;
 }
 
 export function widgetToDOM(info: string, text: string) {


### PR DESCRIPTION
- Prevents widget parsing from breaking when content contains multiple `$$`.
- Inserts a zero-width space (`\u200B`) between `$` characters in internal `$$` sequences to keep WYSIWYG rendering correct without affecting visible content.

---
### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

## Description

Previously, widget content containing multiple $$ could break parsing in TUI Editor because the parser would interpret internal $$ as widget delimiters. This change inserts a zero-width space (\u200B) between $ characters in internal $$ sequences within the widget content. This ensures that widgets with multiple $ render correctly and remain safe for WYSIWYG editing, without affecting the visible content.

### Business Case
Any custom widget that contains `$$` breaks widget rendering and markdown passing. EG, a widget that renders a copy button beside test for a VM password, if the password contains `$$`, then TUI visual mode breaks.

### Issue
Widgets that contain `$$` break in the visual mode of TUI. This is caused by both TUI thinking the first instance of `$$` inside of the widget is the end of the widget. If that section is fixed, then ToastMark walks the line and looks for double dollar signs also breaking rendering further.