### PR TITLE
fix: update toastmark dependency to reference main branch

### DIFF
--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -92,7 +92,7 @@
     "typescript": "^4.2.3"
   },
   "dependencies": {
-    "@toast-ui/toastmark": "github:LearnOnDemandSystems/tui.editor#feat/esm-build-artifacts&path:/libs/toastmark",
+    "@toast-ui/toastmark": "github:LearnOnDemandSystems/tui.editor#main&path:/libs/toastmark",
     "dompurify": "^2.3.3",
     "prosemirror-commands": "^1.1.9",
     "prosemirror-history": "^1.1.3",


### PR DESCRIPTION
## Summary

- The `feat/esm-build-artifacts` branch was merged into `main` and deleted, but `apps/editor/package.json` still referenced it as the source for `@toast-ui/toastmark`
- Updates the internal dependency to point to `#main` so `pnpm install` can resolve it when running the `prepare` build script

## Test plan

- [ ] Run `pnpm install` in `lab-on-demand/Skillable.JavaScript` after this merges — the `@toast-ui/editor` `prepare` script should run successfully and produce `dist/esm/index.js`
- [ ] Run `pnpm dev` and confirm no Vite dep-scan errors for `@toast-ui/editor` or `@toast-ui/editor-plugin-code-syntax-highlight`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)