### PR TITLE
fix: expose CSS file in package exports for code-syntax-highlight plugin

### DIFF
--- a/plugins/code-syntax-highlight/package.json
+++ b/plugins/code-syntax-highlight/package.json
@@ -19,7 +19,8 @@
     ".": {
       "import": "./dist/esm/index.js",
       "require": "./dist/toastui-editor-plugin-code-syntax-highlight.js"
-    }
+    },
+    "./dist/toastui-editor-plugin-code-syntax-highlight.css": "./dist/toastui-editor-plugin-code-syntax-highlight.css"
   },
   "types": "types/index.d.ts",
   "files": [


### PR DESCRIPTION
## Summary

- Adds `./dist/toastui-editor-plugin-code-syntax-highlight.css` to the plugin's `exports` map
- Without this entry, bundlers that enforce package exports (Vite/esbuild) reject the deep CSS import used by the `instructions-editor` package:
  ```ts
  import '@toast-ui/editor-plugin-code-syntax-highlight/dist/toastui-editor-plugin-code-syntax-highlight.css'
  ```

## Test plan

- [ ] After merging, run `pnpm update "@toast-ui/editor" "@toast-ui/editor-plugin-code-syntax-highlight"` then `pnpm install` in `lab-on-demand/Skillable.JavaScript`
- [ ] Run `pnpm dev` — confirm no Vite dep-scan errors

🤖 Generated with [Claude Code](https://claude.ai/claude-code)