### PR TITLE
fix: declare resize-observer-polyfill as runtime dependency

### DIFF
--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -94,6 +94,7 @@
   "dependencies": {
     "@toast-ui/toastmark": "github:LearnOnDemandSystems/tui.editor#main&path:/libs/toastmark",
     "dompurify": "^2.3.3",
+    "resize-observer-polyfill": "^1.5.1",
     "prosemirror-commands": "^1.1.9",
     "prosemirror-history": "^1.1.3",
     "prosemirror-inputrules": "^1.1.3",


### PR DESCRIPTION
## Summary

- \`@toast-ui/editor\`'s ESM bundle (\`dist/esm/index.js\`) imports \`resize-observer-polyfill\` directly
- The package never declared it in \`dependencies\`, so pnpm never installs it alongside the package
- Consumers building with Vite/Rollup fail with: \`Rollup failed to resolve import "resize-observer-polyfill" from @toast-ui/editor/dist/esm/index.js\`

## Fix

Added \`resize-observer-polyfill: ^1.5.1\` to \`dependencies\` in \`apps/editor/package.json\`. No bundler externalization workarounds needed.